### PR TITLE
Rename ProductGetted constant to ProductRetrieved

### DIFF
--- a/Business/Concrete/ProductManager.cs
+++ b/Business/Concrete/ProductManager.cs
@@ -105,7 +105,7 @@ namespace Business.Concrete
         public IDataResult<Product> GetById(int productId)
         {
             var product = _productDal.Get(p => p.ProductId == productId);
-            return new SuccessDataResult<Product>(product, Messages.ProductGetted);
+            return new SuccessDataResult<Product>(product, Messages.ProductRetrieved);
         }
 
         private IResult CheckCategoryIfGreaterThenMaxValue(int categoryId)

--- a/Business/Constants/Messages.cs
+++ b/Business/Constants/Messages.cs
@@ -10,7 +10,7 @@ namespace Business.Constants
     public static class Messages
     {
         public static string ProductAdded = "Product added.";
-        public static string ProductGetted = "Product retrieved.";
+        public static string ProductRetrieved = "Product retrieved.";
         public static string ProductNameInvalid = "Product name is invalid.";
         public static string ProductDeleted = "Product deleted.";
         public static string ProductUpdated = "Product updated.";


### PR DESCRIPTION
## Summary
- Rename ProductGetted constant to ProductRetrieved in Messages
- Update ProductManager to use ProductRetrieved message

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a46c10346c8320b4ccdca5c78a49f3